### PR TITLE
Remove ds.check_permission and ds.check_relation from the manifest.

### DIFF
--- a/content/src/.manifest
+++ b/content/src/.manifest
@@ -18,34 +18,6 @@
           }
         },
         {
-          "name": "ds.check_permission",
-          "decl": {
-            "args": [
-              {
-                "type": "any"
-              }
-            ],
-            "result": {
-              "type": "boolean"
-            },
-            "type": "function"
-          }
-        },
-        {
-          "name": "ds.check_relation",
-          "decl": {
-            "args": [
-              {
-                "type": "any"
-              }
-            ],
-            "result": {
-              "type": "boolean"
-            },
-            "type": "function"
-          }
-        },
-        {
           "name": "ds.graph",
           "decl": {
             "args": [


### PR DESCRIPTION
`ds.check_permission` and `ds.check_relation` were removed in 
https://github.com/aserto-templates/policy-rebac/pull/5 but they were not removed from the manifest